### PR TITLE
Increase robustness of t.array in sparse arrays

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,7 +19,7 @@ globals = {
 	-- debug library
 	"debug.profilebegin", "debug.profileend",
 
-	"it", "expect",
+	"it", "expect", "describe",
 }
 
 -- fix methods

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -711,8 +711,14 @@ do
 				return false, string.format("[array] %s", keyErrMsg or "")
 			end
 
-			-- all keys are sequential
-			local arraySize = #value
+			-- # is unreliable for sparse arrays
+			-- Count upwards using ipairs to avoid false positives from the behavior of #
+			local arraySize = 0
+
+			for _, _ in ipairs(value) do
+				arraySize = arraySize + 1
+			end
+
 			for key in pairs(value) do
 				if key < 1 or key > arraySize then
 					return false, string.format("[array] key %s must be sequential", tostring(key))

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -104,23 +104,35 @@ return function()
 		expect(integerMax5000("1")).to.equal(false)
 	end)
 
-	it("should support array  types", function()
-		local stringArray = t.array(t.string)
-		local anyArray = t.array(t.any)
-		local stringValues = t.values(t.string)
-		expect(anyArray("foo")).to.equal(false)
-		expect(anyArray({1, "2", 3})).to.equal(true)
-		expect(stringArray({1, "2", 3})).to.equal(false)
-		expect(stringArray()).to.equal(false)
-		expect(stringValues()).to.equal(false)
-		expect(anyArray({"1", "2", "3"}, t.string)).to.equal(true)
-		expect(anyArray({
-			foo = "bar"
-		})).to.equal(false)
-		expect(anyArray({
-			[1] = "non",
-			[5] = "sequential"
-		})).to.equal(false)
+	describe("array", function()
+		it("should support array  types", function()
+			local stringArray = t.array(t.string)
+			local anyArray = t.array(t.any)
+			local stringValues = t.values(t.string)
+			expect(anyArray("foo")).to.equal(false)
+			expect(anyArray({1, "2", 3})).to.equal(true)
+			expect(stringArray({1, "2", 3})).to.equal(false)
+			expect(stringArray()).to.equal(false)
+			expect(stringValues()).to.equal(false)
+			expect(anyArray({"1", "2", "3"}, t.string)).to.equal(true)
+			expect(anyArray({
+				foo = "bar"
+			})).to.equal(false)
+			expect(anyArray({
+				[1] = "non",
+				[5] = "sequential"
+			})).to.equal(false)
+		end)
+
+		it("should not be fooled by sparse arrays", function()
+			local anyArray = t.array(t.any)
+
+			expect(anyArray({
+				[1] = 1,
+				[2] = 2,
+				[4] = 4,
+			})).to.equal(false)
+		end)
 	end)
 
 	it("should support map types", function()


### PR DESCRIPTION
Closes #19.

The `#` operator in Lua produces incorrect results for some sparse arrays due to its underlying implementation. This table, for instance:

```lua
local sparseArray = {
    [1] = 1,
    [2] = 2,
    [4] = 4,
}
```

has a length of `4` according to `#`, even though it is not a sequential array. This was allowing some tables to slip through `t.array`'s sequential check.