### PR TITLE
Prefer table.unpack to unpack

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -421,7 +421,7 @@ function t.literal(...)
 			literals[i] = t.literal(value)
 		end
 
-		return t.union(unpack(literals))
+		return t.union(table.unpack(literals, 1, size))
 	end
 end
 
@@ -446,7 +446,7 @@ function t.keyOf(keyTable)
 		keys[length] = key
 	end
 
-	return t.literal(unpack(keys, 1, length))
+	return t.literal(table.unpack(keys, 1, length))
 end
 
 --[[**
@@ -464,7 +464,7 @@ function t.valueOf(valueTable)
 		values[length] = value
 	end
 
-	return t.literal(unpack(values, 1, length))
+	return t.literal(table.unpack(values, 1, length))
 end
 
 --[[**

--- a/spec.lua
+++ b/spec.lua
@@ -1,3 +1,6 @@
+-- polyfills
+table.unpack = unpack
+
 -- borrowed from Roact
 
 local LOAD_MODULES = {


### PR DESCRIPTION
Supposedly, `table.unpack` is faster than regular `unpack`. This seems to be true after benchmarking with two benchmarks.

I've attached said benchmarks as well as pictures of their results.

![image](https://user-images.githubusercontent.com/26746527/69582227-5cd18480-0f95-11ea-829c-1c985542ddc9.png)

```Lua
local Functions = {}

local Array = table.create(1000, "CoolAndGood")

Functions["table.unpack"] = function()
    return table.unpack(Array, 1, 1000)
end

Functions["unpack"] = function()
    return unpack(Array, 1, 1000)
end

require(4185109675).new(1, "table.unpack vs unpack", Functions)
```

![image](https://user-images.githubusercontent.com/26746527/69582175-41ff1000-0f95-11ea-90be-481f1a1284a7.png)

```Lua
local Array = table.create(1000, "CoolAndGood")
local RUN_AMOUNT = 1E6
local STRING = "%s took %.4f seconds"

local START_TIME_TABLE = tick()
for _ = 1, RUN_AMOUNT do
    local _ = {table.unpack(Array, 1, 1000)}
end
local END_TIME_TABLE = tick()

local START_TIME_REGULAR = tick()
for _ = 1, RUN_AMOUNT do
    local _ = {unpack(Array, 1, 1000)}
end
local END_TIME_REGULAR = tick()

print(string.format(STRING, "table.unpack", END_TIME_TABLE - START_TIME_TABLE))
print(string.format(STRING, "unpack", END_TIME_REGULAR - START_TIME_REGULAR))
```
