### PR TITLE
Make UnionToIntersection respect inner unions

### DIFF
--- a/lib/t.d.ts
+++ b/lib/t.d.ts
@@ -130,7 +130,13 @@ interface t {
 	/** checks to see if `value` matches any given check */
 	union: <T extends Array<t.check<any>>>(...args: T) => t.check<t.static<ArrayType<T>>>;
 	/** checks to see if `value` matches all given checks */
-	intersection: <T extends Array<t.check<any>>>(...args: T) => t.check<UnionToIntersection<t.static<ArrayType<T>>>>;
+	intersection: <T extends Array<t.check<any>>>(
+	    ...args: T
+	) => T[Exclude<keyof T, keyof Array<any> | "length">] extends infer U
+	    ? (U extends any ? (k: U) => void : never) extends (k: t.check<infer I>) => void
+		? t.check<I>
+		: never
+	    : never;
 	/** checks to see if `value` matches a given interface definition */
 	interface: <T extends { [index: string]: t.check<any> }>(
 		checkTable: T,


### PR DESCRIPTION
A | (B | C) | D previously evaluated to (A & B & C & D), but we want to maintain the (B | C) union. Now, it evaluates to A & (B | C) & D, or (A & B & D) | (A & C & D) when distributed

You can read my full explanation (and old version of the solution) [here](https://discord.com/channels/476080952636997633/506983834877689856/754215232636846100)

(This version is more efficient than my original solution at the above link)