### PR TITLE
Add Wally support

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,5 +1,5 @@
 [package]
 name = "osyrisrblx/t"
-version = "2.0.0"
+version = "1.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"

--- a/wally.toml
+++ b/wally.toml
@@ -3,4 +3,4 @@ name = "osyrisrblx/t"
 version = "1.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
-include = [ "lib", "default.project.json" ]
+include = ["lib", "default.project.json"]

--- a/wally.toml
+++ b/wally.toml
@@ -3,3 +3,4 @@ name = "osyrisrblx/t"
 version = "1.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
+include = [ "lib", "default.project.json" ]

--- a/wally.toml
+++ b/wally.toml
@@ -1,5 +1,8 @@
 [package]
 name = "osyrisrblx/t"
+description = "A Runtime Type Checker for Roblox"
+license = "MIT"
+authors = ["Osyris"]
 version = "1.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,5 @@
+[package]
+name = "osyrisrblx/t"
+version = "2.0.0"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"


### PR DESCRIPTION
This pull request adds Wally support.

# Getting your package on the Wally registry

- Install Wally into your PATH from the [latest GitHub release](https://github.com/UpliftGames/wally/releases)
- Navigate into this project folder with the terminal of your choice
- Run `wally login` and follow the instructions given
- Run `wally install`