### PR TITLE
Only export `init.lua` for use with Rotriever

### DIFF
--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,6 +1,9 @@
 [package]
-name = "osyris/t"
-author = "osyrisrblx"
+name = "t"
+authors = [
+    "osyrisrblx"
+]
 content_root = "lib"
 version = "1.2.5"
 license = "MIT"
+files = [ "init.lua" ]

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -4,6 +4,6 @@ authors = [
     "osyrisrblx"
 ]
 content_root = "lib"
-version = "1.2.5"
+version = "1.2.6"
 license = "MIT"
 files = [ "init.lua" ]


### PR DESCRIPTION
The `rotriever.toml` has been updated so that only `lib/init.lua` gets exported.

Also updated the `name` and `author` fields to align with Rotriever changes.

Also also bumped version to 1.2.6. We'll need a tag and release for these changes to be consumed. Running `rotrieve publish origin` will take care of the tag, then a release can be made based off it.

cc @ZoteTheMighty 