### PR TITLE
Replace usage of nonexistant `Enum.EnumType`

### DIFF
--- a/lib/t.d.ts
+++ b/lib/t.d.ts
@@ -106,7 +106,7 @@ interface t {
 	Vector3int16: t.check<Vector3int16>;
 
 	/** checks if `value` is an EnumItem which belongs to `Enum`. */
-	enum: <T extends { Name: string }>(Enum: Enum.EnumType<T>) => t.check<T>;
+	enum: <T extends Enum>(Enum: T) => t.check<Extract<T[keyof T], EnumItem>>;
 
 	// type functions
 	/** checks to see if `value == literalValue` */


### PR DESCRIPTION
I could be wrong about this, but I don't believe `Enum.EnumType` is currently defined anywhere within the RobloxTS typings as seen [in the search results](https://github.com/search?q=org%3Aroblox-ts+EnumType&type=code) or the [enums definition file](https://github.com/roblox-ts/types/blob/master/include/generated/enums.d.ts). It may have existed before, but I don't see it now.

As such, I've removed it and replaced it with what I believe should achieve what the desired functionality was.

This approach picks out all the `EnumItem` properties so it's more future-proof in-case more methods are added, but if you wanted to stay consistent the approach of specifically excluding `GetEnumItems` could also be taken as it is done [here](https://github.com/roblox-ts/types/blob/master/include/generated/enums.d.ts#L14).

Alternatively, this approach could always be applied there! 😉 
The `Enum.EnumType` type could also potentially just be re-added. The generic should still probably be constrained to an `Enum` though, not `{ Name: string }`.

---

EDIT: It I can confirm it was indeed removed based on commit [2c294fdc82df58c2c6bd031a432e9b15ef75d900](https://github.com/roblox-ts/rbx-roact/commit/2c294fdc82df58c2c6bd031a432e9b15ef75d900) to [`@rbxts/roact`](https://github.com/roblox-ts/rbx-roact).