### PR TITLE
Add Luau typechecking to t

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -127,7 +127,7 @@ type t = {
 	values: <T>(check: tWrapped<T>) -> tWrapped<{[any]: T}>,
 	map: <K, V>(keyCheck: tWrapped<K>, valueCheck: tWrapped<V>) -> tWrapped<{[K]: V}>,
 	set: <V>(valueCheck: tWrapped<V>) -> tWrapped<{[V]: boolean}>,
-	array: tWrapped<{[number]: any}>,
+	array: <V>(check: tWrapped<V>) -> tWrapped<{[number]: V}>,
 	strictArray: (...any) -> tWrapped<{[number]: any}>,
 	union: tUnionCompromise,
 	some: tUnionCompromise,


### PR DESCRIPTION
Adds typechecking for nearly the entire t library making it infer types on values whenever a test is called with the given value.

There are some limitations to this:
`t.union`, `t.intersection`, `t.literal` and `t.tuple` are limited to only 10 values if types are to be inferred correctly
`t.interface` and `t.strictInterface` don't type the given value as the interface at all.
`t.children`, `t.instance`, `t.instanceOf`, `t.instanceIsA` don't properly apply their children tables.
`t.strictArray` only infers the given value as a array because it's not possible to have a array with only a certain size and certain types at certain indexes.
